### PR TITLE
Add HTTP language fallback labels

### DIFF
--- a/languages/en-US.yaml
+++ b/languages/en-US.yaml
@@ -1596,6 +1596,11 @@ ICU:
     HOME_PAGE_HELP: The page that Grav will use as the default landing page
     HTTP_ACCEPT_LANGUAGE: Set language from browser
     HTTP_ACCEPT_LANGUAGE_HELP: You can opt to try to set the language based on `http_accept_language` header tag in the browser
+    HTTP_ACCEPT_LANGUAGE_FALLBACK: Browser Language Fallbacks
+    HTTP_ACCEPT_LANGUAGE_FALLBACK_HELP: Map unsupported browser languages to supported languages when setting the language from the `http_accept_language` header. This does not add supported languages or create language routes.
+    HTTP_ACCEPT_LANGUAGE_FALLBACK_SOURCE_HELP: Specify an unsupported browser language code, e.g. `hr` or `sr-Latn`.
+    HTTP_ACCEPT_LANGUAGE_FALLBACK_TARGETS: Fallback Languages
+    HTTP_ACCEPT_LANGUAGE_FALLBACK_TARGETS_HELP: Please enter a list of supported language codes. The first supported language will be used.
     HTTP_CONNECTIONS: HTTP Connections
     HTTP_CONNECTIONS_HELP: The number of concurrent HTTP connections during multiplexed requests
     HTTP_HEADERS: HTTP Headers


### PR DESCRIPTION
## Summary

- add the five HTTP Accept-Language fallback labels to Admin2's canonical English ICU vocabulary
- mirror the matching `PLUGIN_ADMIN.HTTP_ACCEPT_LANGUAGE_FALLBACK*` blueprint keys from Grav core
- clarify that configured targets must be supported languages and do not create language routes

## Context

Admin2 translation follow-up for getgrav/grav#4209. These entries allow the Grav 2 system configuration form to render the new field without humanized or raw fallback keys.

## Testing

- parsed `languages/en-US.yaml` successfully with Symfony YAML
- `git diff --check`
